### PR TITLE
adds `zj-status-bar` plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-switch](https://github.com/mostafaqanbaryan/zellij-switch) switching between sessions in CLI using `zellij pipe`
 * [vim-zellij-navigator](https://github.com/hiasr/vim-zellij-navigator) Seamless navigation with vim in zellij
 * [zjpane](https://github.com/FuriouZz/zjpane) Navigate between zellij panes easily
+* [zj-status-bar](https://github.com/cristiand391/zj-status-bar) an opinionated fork of the compact-bar plugin
 
 
 # Tutorials


### PR DESCRIPTION
Added my fork of the compact-bar plugin: https://github.com/cristiand391/zj-status-bar

been using it for ~5 months and plan to keep maintaining it for the foreseable future :) 
wasm builds are published on each GH release (just 1 so far 😄 ), 