### PR TITLE
Added Zellix, a nushell wrapper over zellij and helix that allows for a simple plugin system.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zjpane](https://github.com/FuriouZz/zjpane) Navigate between zellij panes easily
 * [zjstatus](https://github.com/dj95/zjstatus) a configurable, themeable statusbar plugin
 
+# Scripts
+
+* [zellix](https://github.com/TheEmeraldBee/zellix) A nushell wrapper over helix that leverages the power of zellij to turn it into a plugin system!
 
 # Tutorials
 


### PR DESCRIPTION
I added my script set that I wrote in nushell to this, not sure what you want the headder to be called, Plugins doesn't feel right, since it isn't even a plugin, it's just a shell script. I put it under the a **Scripts** headder for now, feel free to change this!