### PR TITLE
Add zjswitcher to the list of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zj-quit](https://github.com/cristiand391/zj-quit) a friendly `quit` plugin for zellij 
 * [zjpane](https://github.com/FuriouZz/zjpane) Navigate between zellij panes easily
 * [zjstatus](https://github.com/dj95/zjstatus) a configurable, themeable statusbar plugin
+* [zjswitcher](https://github.com/WingsZeng/zjswitcher) automatically switche between normal mode and locked mode
 
 # Integrations
 


### PR DESCRIPTION
I would like to add [zjswitcher](https://github.com/WingsZeng/zjswitcher) to the list. I developed this plugin to improve my workflow in Zellij. It is similar to [zellij-autolock](https://github.com/fresh2dev/zellij-autolock) but implemented differently and includes some additional features.