### PR TITLE
Add fzf-zellij

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 
 # Integrations
 
+* [fzf-zellij](https://github.com/k-kuroguro/fzf-zellij) Shell script to start fzf in a Zellij floating pane.
 * [theylix](https://codeberg.org/hobgoblina/theylix) Zellij, Helix, and various cli tools ([Yazi](https://github.com/sxyazi/yazi), [Lazygit](https://github.com/jesseduffield/lazygit), [LazySQL](https://github.com/jorgerojas26/lazysql), [Slumber](https://github.com/LucasPickering/slumber), [Serpl](https://github.com/yassinebridi/serpl), `git blame` via [Tig](https://github.com/jonas/tig)) as a zen-mode IDE
 * [yazelix](https://github.com/luccahuguet/yazelix) zellij, yazi and nushell adding a File Tree to Helix & helix-friendly keybindigs for zellij!
 * [zeco](https://github.com/julianbuettner/zeco) Share your zellij session over the internet, easy and secure!


### PR DESCRIPTION
I'd like to add fzf-zellij, a script that opens fzf inside a Zellij floating pane.
I added it under the Integration section, but it might not be the most appropriate place.