### PR TITLE
Add opencode-zellij-namer to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 # Integrations
 
 * [fzf-zellij](https://github.com/k-kuroguro/fzf-zellij) Shell script to start fzf in a Zellij floating pane.
+* [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer) AI-powered dynamic session naming for [OpenCode](https://opencode.ai), automatically renames sessions based on project context
 * [theylix](https://codeberg.org/hobgoblina/theylix) Zellij, Helix, and various cli tools ([Yazi](https://github.com/sxyazi/yazi), [Lazygit](https://github.com/jesseduffield/lazygit), [LazySQL](https://github.com/jorgerojas26/lazysql), [Slumber](https://github.com/LucasPickering/slumber), [Serpl](https://github.com/yassinebridi/serpl), `git blame` via [Tig](https://github.com/jonas/tig)) as a zen-mode IDE
 * [yazelix](https://github.com/luccahuguet/yazelix) zellij, yazi and nushell adding a File Tree to Helix & helix-friendly keybindigs for zellij!
 * [zeco](https://github.com/julianbuettner/zeco) Share your zellij session over the internet, easy and secure!


### PR DESCRIPTION
## Description

Adds [opencode-zellij-namer](https://github.com/24601/opencode-zellij-namer) to the Integrations section.

## What it does

AI-powered dynamic Zellij session naming plugin for [OpenCode](https://opencode.ai). Automatically renames your Zellij sessions based on:

- **Project context** (directory name, git repo)
- **Work intent** (feat, fix, debug, test, refactor, etc.)
- **Contextual tags** (branch name, file areas, ticket numbers)

### Smart Configuration

- **AGENTS.md aware**: Automatically reads naming guidance from your project's `AGENTS.md` file, allowing teams to define project-specific naming conventions
- **Custom instructions**: Personal overrides via environment variable that take precedence over AGENTS.md
- **Heuristic fallback**: Works without AI when Gemini API is unavailable

Uses Gemini 3 Flash for intelligent naming with stability mechanisms (debounce, cooldown) to prevent excessive renames.

## Links

- **npm**: https://www.npmjs.com/package/opencode-zellij-namer
- **GitHub**: https://github.com/24601/opencode-zellij-namer

## Checklist

- [x] Entry is alphabetically sorted within section
- [x] Description is concise (single line)
- [x] Links work and project is publicly available
- [x] Project is actively maintained