### PR TITLE
Add zellij-tab-bar-indexed plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-qr-share](https://github.com/dbachelder/zellij-qr-share) show a web token as a QR code in the terminal for fast mobile authentication in the web UI.
 * [zellij-sessionizer](https://github.com/laperlej/zellij-sessionizer) create sessions based on folder names
 * [zellij-switch](https://github.com/mostafaqanbaryan/zellij-switch) switching between sessions in CLI using `zellij pipe`
+* [zellij-tab-bar-indexed](https://github.com/ivoronin/zellij-tab-bar-indexed) a tab-bar plugin that adds numeric indices to tabs for quick navigation
 * [zellij-what-time](https://github.com/pirafrank/zellij-what-time) shows host system date and/or time in the status bar. Inspired by zellij-datetime
 * [zellij-workspace](https://github.com/vdbulcke/zellij-workspace) apply layouts to current session
 * [zj-docker](https://github.com/dj95/zj-docker) display docker containers and perform basic operations


### PR DESCRIPTION
Adds [zellij-tab-bar-indexed](https://github.com/ivoronin/zellij-tab-bar-indexed) - a tab-bar plugin that displays numeric indices alongside tab labels for quick navigation.

This is a fork of the default tab-bar plugin with one additional feature: optional tab indices display (`<1>`, `<2>`, etc.).