### PR TITLE
Add zellij-send-keys plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-pane-picker](https://github.com/shihanng/zellij-pane-picker) quickly switch, star, and jump to panes with customizable keyboard shortcuts
 * [zellij-playbooks](https://github.com/yaroslavborbat/zellij-playbooks) browse, select, and execute commands from playbook files directly in the terminal
 * [zellij-qr-share](https://github.com/dbachelder/zellij-qr-share) show a web token as a QR code in the terminal for fast mobile authentication in the web UI.
+* [zellij-send-keys](https://github.com/atani/zellij-send-keys) send text/commands to specific panes like tmux send-keys
 * [zellij-sessionizer](https://github.com/laperlej/zellij-sessionizer) create sessions based on folder names
 * [zellij-switch](https://github.com/mostafaqanbaryan/zellij-switch) switching between sessions in CLI using `zellij pipe`
 * [zellij-what-time](https://github.com/pirafrank/zellij-what-time) shows host system date and/or time in the status bar. Inspired by zellij-datetime


### PR DESCRIPTION
## Summary

Add [zellij-send-keys](https://github.com/atani/zellij-send-keys) to the Plugins section.

**zellij-send-keys** provides `send-keys` functionality similar to tmux, allowing users to send text/commands to specific panes from outside or other panes.

### Features
- Send text to a specific pane by ID
- Get a list of all panes with their IDs
- Optional Enter key after text

### Use case
Useful for automation, scripting, and building multi-agent systems where commands need to be dispatched to different terminal panes.