### PR TITLE
Add zrw to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellix](https://github.com/TheEmeraldBee/zellix) A nushell wrapper over helix that leverages the power of zellij to turn it into a plugin system!
 * [zellij-sessionizer](https://github.com/victor-falcon/zellij-sessionizer) A fuzzy finder-powered project switcher for Zellij sessions, inspired by [ThePrimeagen/tmux-sessionizer](https://github.com/ThePrimeagen/tmux-sessionizer)
 * [zide](https://github.com/josephschmitt/zide) Zellij layouts + bash scripts to create an IDE-like file picker and editor workflow that works in any shell and with most any visual file pickers!
+* [zrw](https://github.com/ivoronin/zrw) run commands in Zellij panes, wait for completion, and propagate exit codes
 
 # Tutorials
 


### PR DESCRIPTION
Add [zrw](https://github.com/ivoronin/zrw) - a CLI utility to run commands in Zellij panes, wait for completion, and propagate exit codes.