### PR TITLE
Add zellij-layoutswitch plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-forgot](https://github.com/karimould/zellij-forgot) swiftly present and access your keybinds (and more)
 * [zellij-getmode](https://github.com/chardskarth/zellij-getmode) a simple utility plugin that gets the current input mode of zellij
 * [zellij-jump-list](https://github.com/blank2121/zellij-jump-list) navigate your motions from pane-to-pane (similar to Vim, Neovim, and Emacs jump list)
+* [zellij-layoutswitch](https://github.com/sgtrusty/zellij-layoutswitch) switch between layouts and tab panes natively & efficiently without shell bloat.
 * [zellij-load](https://github.com/Christian-Prather/zellij-load) show system resources such as CPU, memory and GPU usage. Similar to [tmux cpu-usage](https://github.com/dracula/tmux/blob/master/docs/CONFIG.md#cpu-usage---up)
 * [zellij-newtab-plus](https://github.com/AlexZasorin/zellij-newtab-plus) create named tabs and navigate using zoxide in one keybind
 * [zellij-notepad](https://github.com/0xble/zellij-notepad) floating notepad pane with configurable editor, position, and timestamped notes


### PR DESCRIPTION
Adds [zellij-layoutswitch](https://github.com/sgtrusty/zellij-layoutswitch) -- to switch between layouts and tab panes natively & efficiently without shell bloat. Instructions for building and setting it up are clearly explained in the readme, uses latest 0.43.1 webasm plugin dependency.