### PR TITLE
Add zellij-bar-theme-config to external tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [jbz (Just Bacon Zellij)](https://github.com/nim65s/jbz) display your just commands wrapped in bacon
 * [zellijira](https://github.com/dam4rus/zellijira) Manage sessions around on Jira issues
 * [zellij-theme-configurator](https://rosmur.github.io/zellij-theme-configurator/) A web GUI for creating and exporting Zellij themes
+* [zellij-bar-theme-config](https://github.com/allisonhere/zellij-bar-theme-config) A terminal UI for creating, editing, and applying Zellij themes.
 * [zellij-vscode-toolkit](https://github.com/atoolz/zellij-vscode-toolkit) VS Code extension with IntelliSense, validation, hover docs, color preview, and snippets for Zellij config and layout files
 * [zj-docker](https://github.com/dj95/zj-docker) display docker containers and perform basic operations
 * [zj-git-branch](https://github.com/dam4rus/zj-git-branch) Manage git branches


### PR DESCRIPTION
 This adds zellij-bar-theme-config to the External Tools section.

  zellij-bar-theme-config is a terminal UI for creating, editing, and applying Zellij themes.