### PR TITLE
Add zellij-theme-maker

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [jbz (Just Bacon Zellij)](https://github.com/nim65s/jbz) display your just commands wrapped in bacon
 * [zellijira](https://github.com/dam4rus/zellijira) Manage sessions around on Jira issues
 * [zellij-theme-configurator](https://rosmur.github.io/zellij-theme-configurator/) A web GUI for creating and exporting Zellij themes
+* [zellij-theme-maker](https://github.com/botmiao/zellij-theme-maker) A web-based theme editor with live preview, color picker, and KDL export
 * [zellij-vscode-toolkit](https://github.com/atoolz/zellij-vscode-toolkit) VS Code extension with IntelliSense, validation, hover docs, color preview, and snippets for Zellij config and layout files
 * [zj-docker](https://github.com/dj95/zj-docker) display docker containers and perform basic operations
 * [zj-git-branch](https://github.com/dam4rus/zj-git-branch) Manage git branches


### PR DESCRIPTION
## Summary
- Add [zellij-theme-maker](https://github.com/botmiao/zellij-theme-maker) to the External Tools section

zellij-theme-maker is a web-based theme editor for Zellij with:
- Live terminal preview
- Interactive color picker (react-colorful)
- KDL export (copy to clipboard or download)
- Import existing KDL theme files
- Built-in preset themes (Synthwave 84, Dracula, Nord, Catppuccin)