### PR TITLE
Add zellij-history-selector to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 
 * [grab](https://github.com/imsnif/grab) A fuzzy finder (files, structs, enums, functions) for Rust devs
 * [monocole](https://github.com/imsnif/monocle) fuzzy find of file names and contents
+* [zellij-history-selector](https://github.com/longhongc/zellij-history-selector) floating history picker for shell, IPython, SQLite, clipboard, and custom sources with preview and insert/copy/execute actions
 
 ## Utilities
 


### PR DESCRIPTION
 ## Summary

This PR adds [zellij-history-selector](https://github.com/longhongc/zellij-history-selector) to the Awesome Zellij plugin list.

`zellij-history-selector` is a floating Zellij plugin for searching and reusing history from multiple sources, including shell
history, IPython history, SQLite-backed stores, clipboard tools like CopyQ, and custom exporters through `command_lines` and
`command_json`.

It provides preview, provider switching, and lets users insert, execute, or copy the selected entry back into their workflow.