### PR TITLE
Add zellij-delaylock plugin to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-vertical-tabs (⭐41)](https://github.com/cfal/zellij-vertical-tabs) a plugin that displays tabs vertically as rows
 * [zellij-workspace (⭐35)](https://github.com/vdbulcke/zellij-workspace) apply layouts to current session
 * [zjswitcher (⭐13)](https://github.com/WingsZeng/zjswitcher) automatically switch between normal mode and locked mode
+* [zellij-delaylock] (https://github.com/codingfragments/zellij-delaylock) A simple plugin that would help to get back to locked mode after hitting the leader for tmux or unlock, timeout configurable
 
 ## Search
 


### PR DESCRIPTION
Added zellij-delaylock plugin to the list of plugins.

delaylock is a simple helper that would prevent to get stuck in the tmux or unlocked mode unexpectedly. It loads in the background, wait for an configurable delay after mode changes and will force back into locked/default when still in the transient mode after the time expires. Keypresses in the transient modes restart the timer.