### PR TITLE
Adding zellij-zextract a tmux-fingers and fzf-links replacement in pure rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [grab (⭐22)](https://github.com/imsnif/grab) A fuzzy finder (files, structs, enums, functions) for Rust devs
 * [monocole (⭐188)](https://github.com/imsnif/monocle) fuzzy find of file names and contents
 * [zellij-history-selector (⭐8)](https://github.com/longhongc/zellij-history-selector) floating history picker for shell, IPython, SQLite, clipboard, and custom sources with preview and insert/copy/execute actions
+* [zextract (https://github.com/codingfragments/zellij-zextract)] popup selector that will identify different type of data elemtens and allow for an easy select and copy, heavily inspired by tmux-fingers, fzf-links and others but done in 100% rust and in one combined plugin. 
 
 ## Utilities
 


### PR DESCRIPTION
added https://github.com/codingfragments/zellij-zextract as the plugin to solve most search and copy use cases and close the gap to a full fledged tmux/tpm setup, at least for me.