### PR TITLE
Add zjsh to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-switch (⭐48)](https://github.com/mostafaqanbaryan/zellij-switch) switching between sessions in CLI using `zellij pipe`
 * [zellij-worktree (⭐3)](https://github.com/sharph/zellij-worktree) A Zellij plugin for managing git worktrees
 * [zsm (⭐34)](https://github.com/liam-mackie/zsm) A zoxide-integrated session switcher with support for default layouts
+* [zjsh](https://github.com/saweima12/zjsh) a Zellij session launcher with project config, session discovery, resurrection support, zoxide integration, and fzf/gum support
 
 ## Status Bar
 


### PR DESCRIPTION
<img width="1812" height="1070" alt="image" src="https://github.com/user-attachments/assets/428ee15d-58a8-4192-ba6a-95b91d02cca3" />

Hi, I’d like to add zjsh to the Session Management section.

zjsh is a Zellij session launcher that can list configured projects, existing sessions, resurrectable sessions, and zoxide paths in one place, then open the selected target through fzf or gum.

Repository: https://github.com/tassis/zjsh

Thanks for taking a look!