### PR TITLE
Add lazy-zellij to Session Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 
 ## Session Management
 
+* [lazy-zellij (⭐0)](https://github.com/Logos-Flux/lazy-zellij) an fzf session picker with live preview (tabs, per-pane commands, screen snapshot), systemd autostart, and remote sessions over SSH
 * [zbuffers (⭐21)](https://github.com/Strech/zbuffers) a minimal and convenient way to switch between tabs, inspired by Emacs vertico-buffers and Zellij session-manager
 * [zellij-attention (⭐36)](https://github.com/KiryuuLight/zellij-attention) add notification icons to tab names when panes need attention, designed for Claude Code
 * [zellij-autolock (⭐150)](https://github.com/fresh2dev/zellij-autolock) Automatically lock Zellij depending on the command in the focused pane. Seamless navigation for Vim and more. Pairs well with [zellij.vim](https://github.com/fresh2dev/zellij.vim).


### PR DESCRIPTION
Adds [lazy-zellij](https://github.com/Logos-Flux/lazy-zellij) to the Session Management section.

It is an fzf-based session manager for zellij: a fuzzy picker that fuses live, exited-but-resurrectable, and systemd-managed sessions into one list, with a preview pane showing each session's tabs, per-pane commands (via `zellij action dump-layout`, so it works on detached sessions too), attached clients, and a periodically-captured screen snapshot. It can also promote a session to a boot-time `zellij@<name>` systemd unit straight from the picker, and browse sessions on remote hosts over SSH (`lzj @host`).

MIT licensed. Entry inserted alphabetically at the top of the section.