### PR TITLE
docs: rename zellij-bar-theme-config to zellit

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [gitpod.zellij (⭐9)](https://github.com/gitpod-samples/gitpod.zellij) Zellij plugin for Gitpod, with .gitpod.yml tasks integration
 * [jbz (Just Bacon Zellij) (⭐45)](https://github.com/nim65s/jbz) display your just commands wrapped in bacon
 * [zellijira (⭐2)](https://github.com/dam4rus/zellijira) Manage sessions around on Jira issues
-* [zellij-bar-theme-config (⭐10)](https://github.com/allisonhere/zellij-bar-theme-config) A terminal UI for creating, editing, and applying Zellij themes.
+* [zellit (⭐10)](https://github.com/allisonhere/zellit) A terminal UI for creating, editing, and applying Zellij themes.
 * [zellij-theme-configurator](https://rosmur.github.io/zellij-theme-configurator/) A web GUI for creating and exporting Zellij themes
 * [zellij-vscode-toolkit (⭐9)](https://github.com/atoolz/zellij-vscode-toolkit) VS Code extension with IntelliSense, validation, hover docs, color preview, and snippets for Zellij config and layout files
 * [zj-docker (⭐42)](https://github.com/dj95/zj-docker) display docker containers and perform basic operations


### PR DESCRIPTION
The repository [zellij-bar-theme-config](https://github.com/allisonhere/zellij-bar-theme-config) has been renamed to [zellit](https://github.com/allisonhere/zellit). This PR updates the awesome-zellij listing to reflect the new name.