### PR TITLE
Add Zellij Cheatsheet to Documentation and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,4 +119,5 @@ All the resources listed are community-driven: we cannot offer support but sugge
 ## Documentation and support
 
 * [The zellij docs](https://zellij.dev/documentation/introduction)
+* [Zellij Cheatsheet](https://zellijcheatsheet.dev/) - a fast, searchable reference covering panes, tabs, sessions and layouts, with copy-to-clipboard commands
 * and of course the zellij [Discord](https://discord.com/invite/CrUAFH3) and [Matrix](https://matrix.to/#/#zellij_general:matrix.org) for questions, support and discussions


### PR DESCRIPTION
Adds [Zellij Cheatsheet](https://zellijcheatsheet.dev/) under **Tutorials → Documentation and support**, next to the zellij docs.

It's a fast, searchable quick-reference covering every essential command — panes, tabs, sessions, scroll, resize, layouts — with copy-to-clipboard on each command and light/dark themes. Free, no ads or tracking.

Happy to move it under **Basics** instead — or, if you'd prefer, to add a dedicated **Cheat Sheets** section (as awesome-tmux and several other awesome lists do). Just let me know.

Disclosure: I'm the author — glad to adjust wording or placement to fit the list's style.