### PR TITLE
Add zellij-urlview to integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [yazelix (⭐1k)](https://github.com/luccahuguet/yazelix) zellij, yazi and nushell adding a File Tree to Helix & helix-friendly keybindigs for zellij!
 * [zeco (⭐69)](https://github.com/julianbuettner/zeco) Share your zellij session over the internet, easy and secure!
 * [zellij-sessionizer (⭐47)](https://github.com/victor-falcon/zellij-sessionizer) A fuzzy finder-powered project switcher for Zellij sessions, inspired by [ThePrimeagen/tmux-sessionizer](https://github.com/ThePrimeagen/tmux-sessionizer)
+* [zellij-urlview](https://github.com/VV0JC13CH/zellij-urlview) Quickly open displayed url(s)! Inspired by [tmux-urlview](https://github.com/tmux-plugins/tmux-urlview)
 * [zellix (⭐50)](https://github.com/TheEmeraldBee/zellix) A nushell wrapper over helix that leverages the power of zellij to turn it into a plugin system!
 * [zide (⭐319)](https://github.com/josephschmitt/zide) Zellij layouts + bash scripts to create an IDE-like file picker and editor workflow that works in any shell and with most any visual file pickers!
 * [zrw (⭐4)](https://github.com/ivoronin/zrw) run commands in Zellij panes, wait for completion, and propagate exit codes


### PR DESCRIPTION
This integration adds floating pane with fzf/urlview containing displayed urls. It allows to quickly open them in the browser.