### PR TITLE
Add zellij-leap

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-nvim-nav-plugin (⭐13)](https://github.com/sharph/zellij-nvim-nav-plugin) Another plugin for seamless navigation with neovim/vim windows
 * [zellij-pane-picker (⭐26)](https://github.com/shihanng/zellij-pane-picker) quickly switch, star, and jump to panes with customizable keyboard shortcuts
 * [zjpane (⭐14)](https://github.com/FuriouZz/zjpane) Navigate between zellij panes easily
+* [zellij-leap (⭐0)](https://github.com/Picalines/zellij-leap) Switch to tabs / panes / sessions with as few keys as possible
 
 ## Session Management
 


### PR DESCRIPTION
Hi there! Zellij is very nice to work with, but I didn't enjoy manually switching my tabs and managing their order

I made a [zellij-leap](https://github.com/Picalines/zellij-leap) plugin that allows me to press a single unique key of the tabs title, and the plugin will close itself and bring me there. It works great when i have simple tabs like "**c**ode & **g**it & **b**uild"

Later I expanded it to sessions, which I like more than a built-in session manager (only for switching!). Panes are also supported, but I don't open more than two usually. It also handles non-unique letters and allows regular arrow keys

It'll be great if someone also finds it useful :)

![zellij-leap gif](https://github.com/Picalines/zellij-leap/raw/main/assets/demo.cast.gif)