### PR TITLE
Add noren - zellij session-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 ## Session Management
 
 * [lazy-zellij (⭐0)](https://github.com/Logos-Flux/lazy-zellij) an fzf session picker with live preview (tabs, per-pane commands, screen snapshot), systemd autostart, and remote sessions over SSH
-* [noren](⭐0)(https://github.com/MaySeikatsu/noren) A sesh-style session manager for zellij - brush through the curtain into any project 
+* [noren(⭐0)](https://github.com/MaySeikatsu/noren) A sesh-style session manager for zellij - brush through the curtain into any project 
 * [zbuffers (⭐21)](https://github.com/Strech/zbuffers) a minimal and convenient way to switch between tabs, inspired by Emacs vertico-buffers and Zellij session-manager
 * [zellij-attention (⭐36)](https://github.com/KiryuuLight/zellij-attention) add notification icons to tab names when panes need attention, designed for Claude Code
 * [zellij-autolock (⭐150)](https://github.com/fresh2dev/zellij-autolock) Automatically lock Zellij depending on the command in the focused pane. Seamless navigation for Vim and more. Pairs well with [zellij.vim](https://github.com/fresh2dev/zellij.vim).

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 ## Session Management
 
 * [lazy-zellij (⭐0)](https://github.com/Logos-Flux/lazy-zellij) an fzf session picker with live preview (tabs, per-pane commands, screen snapshot), systemd autostart, and remote sessions over SSH
+* [noren](⭐0)(https://github.com/MaySeikatsu/noren) A sesh-style session manager for zellij - brush through the curtain into any project 
 * [zbuffers (⭐21)](https://github.com/Strech/zbuffers) a minimal and convenient way to switch between tabs, inspired by Emacs vertico-buffers and Zellij session-manager
 * [zellij-attention (⭐36)](https://github.com/KiryuuLight/zellij-attention) add notification icons to tab names when panes need attention, designed for Claude Code
 * [zellij-autolock (⭐150)](https://github.com/fresh2dev/zellij-autolock) Automatically lock Zellij depending on the command in the focused pane. Seamless navigation for Vim and more. Pairs well with [zellij.vim](https://github.com/fresh2dev/zellij.vim).


### PR DESCRIPTION
PR adds noren to the list of zellij utils in the subsection session manager - position in list chosen alphabetically 