### PR TITLE
Add zj-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-what-time (⭐16)](https://github.com/pirafrank/zellij-what-time) shows host system date and/or time in the status bar. Inspired by zellij-datetime
 * [zjstatus (⭐1k)](https://github.com/dj95/zjstatus) a configurable, themeable statusbar plugin
 * [zjstatus-hints (⭐82)](https://github.com/b0o/zjstatus-hints) adds mode-aware key binding hints to zjstatus
+* [zj-agents](https://github.com/kaankoken/zj-agents) background engine + floating sidebar: classify coding-agent panes (Idle/Working/Blocked/Done) from process + viewport manifests, desktop notifications; Claude, Codex, Grok, Pi, OMP
 * [zj-radar (⭐5)](https://github.com/marktoda/zj-radar) a pinned sidebar showing which AI agents (Claude Code, Codex) are working, done, or waiting for you across all tabs, with click-to-jump
 * [zj-status-bar (⭐35)](https://github.com/cristiand391/zj-status-bar) an opinionated fork of the compact-bar plugin
 


### PR DESCRIPTION
## Summary

Adds [zj-agents](https://github.com/kaankoken/zj-agents) under **Status Bar**, next to [zj-radar](https://github.com/marktoda/zj-radar) (closest related project).

**What it is:** stock Zellij ≥ 0.44.3 plugin pair (background engine + floating sidebar) that discovers coding-agent panes, classifies Idle/Working/Blocked/Done from process basenames + viewport rules (fixture-backed: Claude, Codex, Grok, Pi, OMP), and can send desktop notifications on Blocked/Done.

**How to install:** GitHub Release WASM assets (`v0.1.0`+): https://github.com/kaankoken/zj-agents/releases/latest

**How it differs from listed peers:**
- **zj-radar** — push/pipe producers; pinned rail
- **zellaude** — Claude-focused status bar + hooks
- **zj-agents** — pull classification via manifests/fixtures; engine + hideable sidebar; multi-agent without requiring agent hooks

## Checklist

- [x] Public repo with README install docs
- [x] Release with downloadable `.wasm` artifacts
- [x] Entry placed next to related plugins (Status Bar / beside zj-radar)