### PR TITLE
Add zellij-ai-stats to Status Bar plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,17 +38,12 @@ All the resources listed are community-driven: we cannot offer support but sugge
 
 ## Status Bar
 
-* [showy-quota (⭐15)](https://github.com/enieuwy/showy-quota) a standalone WASM status bar plugin showing live AI coding-plan quotas (Codex, Claude, Copilot, Gemini…), driven by CodexBar
-* [zellaude (⭐102)](https://github.com/ishefi/zellaude) a status bar plugin that shows Claude Code activity indicators on tabs
-* [zellij-ai-stats](https://github.com/ericviana/zellij-ai-stats) a themed powerline bar showing weekly quota usage and reset times for Claude Code and Codex, plus how many agent sessions are running
 * [zellij-cb (⭐50)](https://github.com/ndavd/zellij-cb) a customizable compact bar for Zellij
 * [zellij-datetime (⭐52)](https://github.com/h1romas4/zellij-datetime) adds a date and time pane to your Zellij
 * [zellij-load (⭐10)](https://github.com/Christian-Prather/zellij-load) show system resources such as CPU, memory and GPU usage. Similar to [tmux cpu-usage](https://github.com/dracula/tmux/blob/master/docs/CONFIG.md#cpu-usage---up)
 * [zellij-what-time (⭐16)](https://github.com/pirafrank/zellij-what-time) shows host system date and/or time in the status bar. Inspired by zellij-datetime
 * [zjstatus (⭐1k)](https://github.com/dj95/zjstatus) a configurable, themeable statusbar plugin
 * [zjstatus-hints (⭐84)](https://github.com/b0o/zjstatus-hints) adds mode-aware key binding hints to zjstatus
-* [zj-agents (⭐2)](https://github.com/kaankoken/zj-agents) background engine + floating sidebar: classify coding-agent panes (Idle/Working/Blocked/Done) from process + viewport manifests, desktop notifications; Claude, Codex, Grok, Pi, OMP
-* [zj-radar (⭐17)](https://github.com/marktoda/zj-radar) a pinned sidebar showing which AI agents (Claude Code, Codex) are working, done, or waiting for you across all tabs, with click-to-jump
 * [zj-status-bar (⭐36)](https://github.com/cristiand391/zj-status-bar) an opinionated fork of the compact-bar plugin
 
 ## UI & Modes
@@ -86,6 +81,16 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-send-keys (⭐21)](https://github.com/atani/zellij-send-keys) send text/commands to specific panes like tmux send-keys
 * [zj-quit (⭐45)](https://github.com/cristiand391/zj-quit) a friendly `quit` plugin for zellij
 
+## Coding Agent Management
+
+* [captain-miao (⭐0)](https://github.com/hyperlogue/captain-miao) TUI to monitor and organize multiple AI coding sessions in zellij, through `zellij action`.
+* [showy-quota (⭐15)](https://github.com/enieuwy/showy-quota) a standalone WASM status bar plugin showing live AI coding-plan quotas (Codex, Claude, Copilot, Gemini…), driven by CodexBar
+* [opencode-zellij-namer (⭐65)](https://github.com/24601/opencode-zellij-namer) AI-powered dynamic session naming for [OpenCode](https://opencode.ai), automatically renames sessions based on project context
+* [zellaude (⭐105)](https://github.com/ishefi/zellaude) a status bar plugin that shows Claude Code activity indicators on tabs
+* [zj-agents (⭐2)](https://github.com/kaankoken/zj-agents) background engine + floating sidebar: classify coding-agent panes (Idle/Working/Blocked/Done) from process + viewport manifests, desktop notifications; Claude, Codex, Grok, Pi, OMP
+* [zellij-ai-stats](https://github.com/ericviana/zellij-ai-stats) a themed powerline bar showing weekly quota usage and reset times for Claude Code and Codex, plus how many agent sessions are running
+* [zj-radar (⭐18)](https://github.com/marktoda/zj-radar) a pinned sidebar showing which AI agents (Claude Code, Codex) are working, done, or waiting for you across all tabs, with click-to-jump
+
 ## External Tools
 
 * [gitpod.zellij (⭐9)](https://github.com/gitpod-samples/gitpod.zellij) Zellij plugin for Gitpod, with .gitpod.yml tasks integration
@@ -102,7 +107,6 @@ All the resources listed are community-driven: we cannot offer support but sugge
 # Integrations
 
 * [fzf-zellij (⭐15)](https://github.com/k-kuroguro/fzf-zellij) Shell script to start fzf in a Zellij floating pane.
-* [opencode-zellij-namer (⭐65)](https://github.com/24601/opencode-zellij-namer) AI-powered dynamic session naming for [OpenCode](https://opencode.ai), automatically renames sessions based on project context
 * [theylix](https://codeberg.org/hobgoblina/theylix) Zellij, Helix, and various cli tools ([Yazi](https://github.com/sxyazi/yazi), [Lazygit](https://github.com/jesseduffield/lazygit), [LazySQL](https://github.com/jorgerojas26/lazysql), [Slumber](https://github.com/LucasPickering/slumber), [Serpl](https://github.com/yassinebridi/serpl), `git blame` via [Tig](https://github.com/jonas/tig)) as a zen-mode IDE
 * [yazelix (⭐1.1k)](https://github.com/luccahuguet/yazelix) zellij, yazi and nushell adding a File Tree to Helix & helix-friendly keybindigs for zellij!
 * [zeco (⭐74)](https://github.com/julianbuettner/zeco) Share your zellij session over the internet, easy and secure!

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 
 * [showy-quota (⭐15)](https://github.com/enieuwy/showy-quota) a standalone WASM status bar plugin showing live AI coding-plan quotas (Codex, Claude, Copilot, Gemini…), driven by CodexBar
 * [zellaude (⭐102)](https://github.com/ishefi/zellaude) a status bar plugin that shows Claude Code activity indicators on tabs
+* [zellij-ai-stats](https://github.com/ericviana/zellij-ai-stats) a themed powerline bar showing weekly quota usage and reset times for Claude Code and Codex, plus how many agent sessions are running
 * [zellij-cb (⭐50)](https://github.com/ndavd/zellij-cb) a customizable compact bar for Zellij
 * [zellij-datetime (⭐52)](https://github.com/h1romas4/zellij-datetime) adds a date and time pane to your Zellij
 * [zellij-load (⭐10)](https://github.com/Christian-Prather/zellij-load) show system resources such as CPU, memory and GPU usage. Similar to [tmux cpu-usage](https://github.com/dracula/tmux/blob/master/docs/CONFIG.md#cpu-usage---up)


### PR DESCRIPTION
Adds zellij-ai-stats, a status bar plugin showing weekly quota usage and reset times for coding agent CLIs, alongside a count of running agent sessions.

Colors and separators come from the active zellij theme, so it matches the tab bar.