### PR TITLE
Add zj-agent-mob to Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [opencode-zellij-namer (⭐65)](https://github.com/24601/opencode-zellij-namer) AI-powered dynamic session naming for [OpenCode](https://opencode.ai), automatically renames sessions based on project context
 * [zellaude (⭐105)](https://github.com/ishefi/zellaude) a status bar plugin that shows Claude Code activity indicators on tabs
 * [zj-agents (⭐2)](https://github.com/kaankoken/zj-agents) background engine + floating sidebar: classify coding-agent panes (Idle/Working/Blocked/Done) from process + viewport manifests, desktop notifications; Claude, Codex, Grok, Pi, OMP
+* [zj-agent-mob](https://github.com/mohseenrm/zj-agent-mob) a floating panel tracking Claude Code and Codex agents across every session: live status, current task, jump-to-pane across sessions, approve/reject permission prompts, and kill runaways
 * [zj-radar (⭐18)](https://github.com/marktoda/zj-radar) a pinned sidebar showing which AI agents (Claude Code, Codex) are working, done, or waiting for you across all tabs, with click-to-jump
 
 ## External Tools


### PR DESCRIPTION
Adds [zj-agent-mob](https://github.com/mohseenrm/zj-agent-mob) to Integrations: a floating panel for keeping track of Claude Code and Codex agents across every Zellij session.

It lets you easily monitor agents, approve/deny when agent needs input, easily jump to pane of running agent, kill rogue agents across sessions.

Zellij 0.44+, prebuilt wasm on the [releases page](https://github.com/mohseenrm/zj-agent-mob/releases) with a one-line installer.

I left the star count off the entry, matching how other contributors add entries, since the stars-updater fills those in. `check_lost_links.py` passes with no links lost.

### Demo
<img width="1500" height="900" alt="tour" src="https://github.com/user-attachments/assets/e6c51f29-5bd0-48fc-ad19-a048aaf4d0da" />
