### PR TITLE
Add zjstatus-hints (fork) plugin details

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ All the resources listed are community-driven: we cannot offer support but sugge
 * [zellij-what-time (⭐16)](https://github.com/pirafrank/zellij-what-time) shows host system date and/or time in the status bar. Inspired by zellij-datetime
 * [zjstatus (⭐1k)](https://github.com/dj95/zjstatus) a configurable, themeable statusbar plugin
 * [zjstatus-hints (⭐82)](https://github.com/b0o/zjstatus-hints) adds mode-aware key binding hints to zjstatus
+* [zjstatus-hints (fork) (⭐3)](https://github.com/myah-mitchell/zjstatus-hints) adds mode-aware key binding hints to zjstatus, with styling, keybind discovery, and width-aware fitting
 * [zj-status-bar (⭐35)](https://github.com/cristiand391/zj-status-bar) an opinionated fork of the compact-bar plugin
 
 ## UI & Modes


### PR DESCRIPTION
  Adds an entry for my fork of zjstatus-hints, per discussion in #70.

  The original (b0o/zjstatus-hints) hasn't seen updates in a while. My fork has diverged with a few additions:

  - format-string styling and modifier aliases
  - automatic discovery of keybindings from the Zellij config
  - label customization
  - keyboard-layout-aware ordering
  - responsive fitting so hints don't overflow the status bar width

  Listed as a separate entry rather than replacing the original, since
  b0o's repo is still the upstream. 

  Closes #70